### PR TITLE
clickhouse: fix go reference API doc

### DIFF
--- a/clickhouse/client.go
+++ b/clickhouse/client.go
@@ -1,4 +1,3 @@
-// Package clickhouse 封装标准库clickhouse
 package clickhouse
 
 import (

--- a/clickhouse/client_test.go
+++ b/clickhouse/client_test.go
@@ -1,9 +1,3 @@
-/**
- * @author aceyugong <aceyugong@tencent.com>
- * @date 2022/7/4
- */
-
-// Package clickhouse packages standard library clickhouse.
 package clickhouse
 
 import (

--- a/clickhouse/codec_test.go
+++ b/clickhouse/codec_test.go
@@ -1,4 +1,3 @@
-// Package clickhouse packages standard library clickhouse.
 package clickhouse
 
 import (

--- a/clickhouse/dsn_test.go
+++ b/clickhouse/dsn_test.go
@@ -1,9 +1,3 @@
-/**
- * @author aceyugong <aceyugong@tencent.com>
- * @date 2022/8/19
- */
-
-// Package clickhouse packages standard library clickhouse.
 package clickhouse
 
 import (

--- a/clickhouse/mockclickhouse/clickhouse_mock.go
+++ b/clickhouse/mockclickhouse/clickhouse_mock.go
@@ -9,8 +9,8 @@ import (
 	sql "database/sql"
 	reflect "reflect"
 
-	clickhouse "trpc.group/trpc-go/trpc-database/clickhouse"
 	gomock "github.com/golang/mock/gomock"
+	clickhouse "trpc.group/trpc-go/trpc-database/clickhouse"
 )
 
 // MockClient is a mock of Client interface.

--- a/clickhouse/transport_test.go
+++ b/clickhouse/transport_test.go
@@ -1,4 +1,3 @@
-// Package clickhouse packages standard library clickhouse.
 package clickhouse
 
 import (


### PR DESCRIPTION
https://pkg.go.dev/trpc.group/trpc-go/trpc-database/clickhouse

<img width="712" alt="image" src="https://github.com/trpc-ecosystem/go-database/assets/53028871/941e01e5-8db7-4b4c-9b17-734ac252cb8c">
